### PR TITLE
Makefile improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PTHREADINCLUDE=-IC:/cygwin64/usr/i686-pc-mingw32/sys-root/mingw/include
 PTHREADLIB=C:/cygwin64/usr/i686-pc-mingw32/sys-root/mingw/lib/libpthread.a 
 
 OPTIMIZE=-O3
-CXXFLAGS=$(OPTIMIZE) -pthread $(PTHREADINCLUDE) -c -std=c++11 -Wall
+CXXFLAGS=$(OPTIMIZE) -pthread $(PTHREADINCLUDE) -std=c++11 -Wall
 LDFLAGS=
 LDLIBS=$(PTHREADLIB) -lstdc++
 
@@ -45,9 +45,6 @@ all: $(EXECUTABLE)
 
 $(EXECUTABLE): $(OBJECTS) 
 	$(CXX) $(LDFLAGS) $(OBJECTS) $(LDLIBS) -o $@
-
-.cpp.o:
-	$(CXX) $(CXXFLAGS) $< -o $@
 
 clean:
 	$(RM) $(SOURCEPATH)/*.o $(EXECUTABLE)

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ CXXFLAGS=$(OPTIMIZE) -pthread $(PTHREADINCLUDE) -c -std=c++11 -Wall
 LDFLAGS=
 LDLIBS=$(PTHREADLIB) -lstdc++
 
+.PHONY: all clean
+
 SOURCEPATH=src
 SOURCES=$(SOURCEPATH)/aabb.cpp \
 		$(SOURCEPATH)/anisotropicparticlemesher.cpp \

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-PTHREADINCLUDE=C:/cygwin64/usr/i686-pc-mingw32/sys-root/mingw/include
+PTHREADINCLUDE=-IC:/cygwin64/usr/i686-pc-mingw32/sys-root/mingw/include
 PTHREADLIB=C:/cygwin64/usr/i686-pc-mingw32/sys-root/mingw/lib/libpthread.a 
 
 OPTIMIZE=-O3
-CXXFLAGS=$(OPTIMIZE) -pthread -I$(PTHREADINCLUDE) -c -std=c++11 -Wall
+CXXFLAGS=$(OPTIMIZE) -pthread $(PTHREADINCLUDE) -c -std=c++11 -Wall
 LDFLAGS=
 LDLIBS=$(PTHREADLIB) -lstdc++
 

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ SOURCES=$(SOURCEPATH)/aabb.cpp \
 		$(SOURCEPATH)/trianglemesh.cpp \
 		$(SOURCEPATH)/turbulencefield.cpp \
 		$(SOURCEPATH)/vmath.cpp
-		
+
 OBJECTS=$(SOURCES:.cpp=.o)
 EXECUTABLE=fluidsim
 
@@ -48,6 +48,6 @@ $(EXECUTABLE): $(OBJECTS)
 
 .cpp.o:
 	$(CC) $(CFLAGS) $< -o $@
-	
+
 clean:
 	rm $(SOURCEPATH)/*.o $(EXECUTABLE)

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,8 @@
-CC=g++
-
 PTHREADINCLUDE=C:/cygwin64/usr/i686-pc-mingw32/sys-root/mingw/include
 PTHREADLIB=C:/cygwin64/usr/i686-pc-mingw32/sys-root/mingw/lib/libpthread.a 
 
 OPTIMIZE=-O3
-CFLAGS=$(OPTIMIZE) -pthread -I$(PTHREADINCLUDE) -c -std=c++11 -Wall
+CXXFLAGS=$(OPTIMIZE) -pthread -I$(PTHREADINCLUDE) -c -std=c++11 -Wall
 LDFLAGS=
 LDLIBS=$(PTHREADLIB) -lstdc++
 
@@ -44,10 +42,10 @@ EXECUTABLE=fluidsim
 all: $(SOURCES) $(EXECUTABLE)
 
 $(EXECUTABLE): $(OBJECTS) 
-	$(CC) $(LDFLAGS) $(OBJECTS) $(LDLIBS) -o $@
+	$(CXX) $(LDFLAGS) $(OBJECTS) $(LDLIBS) -o $@
 
 .cpp.o:
-	$(CC) $(CFLAGS) $< -o $@
+	$(CXX) $(CXXFLAGS) $< -o $@
 
 clean:
 	$(RM) $(SOURCEPATH)/*.o $(EXECUTABLE)

--- a/Makefile
+++ b/Makefile
@@ -50,4 +50,4 @@ $(EXECUTABLE): $(OBJECTS)
 	$(CC) $(CFLAGS) $< -o $@
 
 clean:
-	rm $(SOURCEPATH)/*.o $(EXECUTABLE)
+	$(RM) $(SOURCEPATH)/*.o $(EXECUTABLE)

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ SOURCES=$(SOURCEPATH)/aabb.cpp \
 OBJECTS=$(SOURCES:.cpp=.o)
 EXECUTABLE=fluidsim
 
-all: $(SOURCES) $(EXECUTABLE)
+all: $(EXECUTABLE)
 
 $(EXECUTABLE): $(OBJECTS) 
 	$(CXX) $(LDFLAGS) $(OBJECTS) $(LDLIBS) -o $@


### PR DESCRIPTION
Various improvements to the Makefile, partially to improve support for building on Linux (d4cd67def26e0db60e4bb1fd8ce3fe8e70008b8c). See the individual commit messages for details.

---

Warning: the last two commits are specific to GNU make. A POSIX-compliant make is not required to have implicit rules for C++ compilation, or to support the `.PHONY` construct. Don’t include these commits if you want to build with other make implementations.

---

An added note for the last commit, 783efd5a30e646097675346b0c0c66dd4c1a9b1f: If you rename `main.cpp` to `fluidsim.cpp`, then you can remove the linking command as well, leaving you with an almost completely implicit Makefile:

``` make
# definitions…

all: $(EXECUTABLE)

$(EXECUTABLE): $(OBJECTS) 

clean:
    $(RM) $(SOURCEPATH)/*.o $(EXECUTABLE)
```

Neat, right? :) This is because GNU make has an implicit rule to link `fluidsim` from `fluidsim.o aabb.o …`, so all we need to do is specify the depending objects. However, this doesn’t work if `fluidsim.o`/`fluidsim.cpp` doesn’t exist.

---

Also: these changes alone are not sufficient to support building on Linux. You need to change the pthread paths, of course –

``` diff
diff --git a/Makefile b/Makefile
index 59cddbb..580437e 100644
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
-PTHREADINCLUDE=-IC:/cygwin64/usr/i686-pc-mingw32/sys-root/mingw/include
-PTHREADLIB=C:/cygwin64/usr/i686-pc-mingw32/sys-root/mingw/lib/libpthread.a 
+PTHREADLIB=-lpthread

 OPTIMIZE=-O3
 CXXFLAGS=$(OPTIMIZE) -pthread $(PTHREADINCLUDE) -std=c++11 -Wall
```

– but even then, on my system the compiler complains that `NULL` is undefined. The correct solution, I think, is to use `nullptr` instead:

``` sh
find src/ -name '*.cpp' -exec sed -i 's/\bNULL\b/nullptr/g' {} +
```

I suggest you make this change, and use `nullptr` in the new code you write as well.

---

And finally, since this project doesn’t have a license yet, I hereby grant you permission to distribute these changes under any license of your choosing.
